### PR TITLE
Add "screen power mode" command

### DIFF
--- a/src/app/controlMessage/CommandControlMessage.ts
+++ b/src/app/controlMessage/CommandControlMessage.ts
@@ -70,6 +70,16 @@ export class CommandControlMessage extends ControlMessage {
         return event;
     }
 
+    public static createSetScreenPowerModeCommand(mode: boolean): CommandControlMessage {
+        const event = new CommandControlMessage(ControlMessage.TYPE_SET_SCREEN_POWER_MODE);
+        let offset = 0;
+        const buffer = Buffer.alloc(1 + 1);
+        offset = buffer.writeInt8(event.type, offset);
+        buffer.writeUInt8(mode ? 1 : 0, offset);
+        event.buffer = buffer;
+        return event;
+    }
+
     public static createPushFileCommand(params: FilePushParams): CommandControlMessage {
         const { id, fileName, fileSize, chunk, state } = params;
 

--- a/src/app/toolbox/DroidMoreBox.ts
+++ b/src/app/toolbox/DroidMoreBox.ts
@@ -169,6 +169,31 @@ export class DroidMoreBox {
         }
         DroidMoreBox.wrap('p', commands, moreBox);
 
+        const screenPowerModeId = `screen_power_mode_${udid}_${playerName}_${displayId}`;
+        const screenPowerModeLabel = document.createElement('label');
+        screenPowerModeLabel.style.display = 'none';
+        const labelTextPrefix = 'Mode';
+        const buttonTextPrefix = 'Set screen power mode';
+        const screenPowerModeCheck = document.createElement('input');
+        screenPowerModeCheck.type = 'checkbox';
+        let mode = (screenPowerModeCheck.checked = false) ? 'ON' : 'OFF';
+        screenPowerModeCheck.id = screenPowerModeLabel.htmlFor = screenPowerModeId;
+        screenPowerModeLabel.innerText = `${labelTextPrefix} ${mode}`;
+        screenPowerModeCheck.onchange = () => {
+            mode = screenPowerModeCheck.checked ? 'ON' : 'OFF';
+            screenPowerModeLabel.innerText = `${labelTextPrefix} ${mode}`;
+            sendScreenPowerModeButton.innerText = `${buttonTextPrefix} ${mode}`;
+        };
+        const sendScreenPowerModeButton = document.createElement('button');
+        sendScreenPowerModeButton.innerText = `${buttonTextPrefix} ${mode}`;
+        sendScreenPowerModeButton.onclick = () => {
+            const message = CommandControlMessage.createSetScreenPowerModeCommand(screenPowerModeCheck.checked);
+            client.sendMessage(message);
+        };
+        DroidMoreBox.wrap('p', [screenPowerModeCheck, screenPowerModeLabel, sendScreenPowerModeButton], moreBox, [
+            'flex-center',
+        ]);
+
         const qualityId = `show_video_quality_${udid}_${playerName}_${displayId}`;
         const qualityLabel = document.createElement('label');
         const qualityCheck = document.createElement('input');
@@ -177,7 +202,7 @@ export class DroidMoreBox {
         qualityCheck.id = qualityId;
         qualityLabel.htmlFor = qualityId;
         qualityLabel.innerText = 'Show quality stats';
-        DroidMoreBox.wrap('p', [qualityCheck, qualityLabel], moreBox);
+        DroidMoreBox.wrap('p', [qualityCheck, qualityLabel], moreBox, ['flex-center']);
         qualityCheck.onchange = () => {
             player.setShowQualityStats(qualityCheck.checked);
         };
@@ -257,8 +282,11 @@ export class DroidMoreBox {
         document.execCommand('copy');
     }
 
-    private static wrap(tagName: string, elements: HTMLElement[], parent: HTMLElement): void {
+    private static wrap(tagName: string, elements: HTMLElement[], parent: HTMLElement, opt_classes?: string[]): void {
         const wrap = document.createElement(tagName);
+        if (opt_classes) {
+            wrap.classList.add(...opt_classes);
+        }
         elements.forEach((e) => {
             wrap.appendChild(e);
         });

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -91,6 +91,11 @@ body.stream {
     outline: none;
 }
 
+.flex-center {
+    display: flex;
+    align-items: center;
+}
+
 .wait {
     cursor: wait;
 }


### PR DESCRIPTION
refs #65

I wasn't able to test `-S/--turn-screen-off` with original scrcpy: on my devices it disables rendering on the screen, so I have static image on it.
I implemented similar behavior (as far as can understand original source code): checkbox and button are under `More` menu (three dots).

@kwiksilver, please try it and let me know if it works as you expected.

Before starting server you can change `LOG_LEVEL` to `'DEBUG'` here: https://github.com/NetrisTV/ws-scrcpy/blob/3227bc6ec7f42c26e04098af63aef51e286d3150/src/server/Constants.ts#L7
to see scrcpy debug messages in logcat.