### PR TITLE
Improve player for ios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5246,9 +5246,9 @@
       "optional": true
     },
     "h264-converter": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/h264-converter/-/h264-converter-0.1.2.tgz",
-      "integrity": "sha512-i69s0i000Op9zxdAKq0j4xw68PcLzJb7vXAApXEI2xyAYb4pz1l2hQRmZ0ZKyMaGDYhwk0rGfi/Zc9Wl5Fie8Q==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/h264-converter/-/h264-converter-0.1.3.tgz",
+      "integrity": "sha512-qe5pdpixvGpRfs3T+0tDdoJ6uIugWKEQx68tjpgCDaHvZ9zDwQaC+MKmY633aC9R1+yhCulG6ZLMqQ7vn8BoRQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.7.1"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-progress": "0.0.1",
     "file-loader": "^6.0.0",
     "generate-package-json-webpack-plugin": "^2.1.2",
-    "h264-converter": "^0.1.2",
+    "h264-converter": "^0.1.3",
     "html-webpack-plugin": "^4.5.0",
     "ifdef-loader": "^2.3.0",
     "mini-css-extract-plugin": "^0.11.2",

--- a/src/app/applDevice/WdaConnection.ts
+++ b/src/app/applDevice/WdaConnection.ts
@@ -32,7 +32,7 @@ export default class WdaConnection {
             return;
         }
         const wdaScreen = this.wdaScreen || (await this.getWdaScreen());
-        const point = await this.calculatePhysicalPoint(this.screenInfo, wdaScreen, position);
+        const point = await WdaConnection.calculatePhysicalPoint(this.screenInfo, wdaScreen, position);
         if (!point) {
             return;
         }
@@ -47,8 +47,8 @@ export default class WdaConnection {
             return;
         }
         const wdaScreen = this.wdaScreen || (await this.getWdaScreen());
-        const fromPoint = this.calculatePhysicalPoint(this.screenInfo, wdaScreen, from);
-        const toPoint = this.calculatePhysicalPoint(this.screenInfo, wdaScreen, to);
+        const fromPoint = WdaConnection.calculatePhysicalPoint(this.screenInfo, wdaScreen, from);
+        const toPoint = WdaConnection.calculatePhysicalPoint(this.screenInfo, wdaScreen, to);
         if (!fromPoint || !toPoint) {
             return;
         }
@@ -75,12 +75,22 @@ export default class WdaConnection {
         throw Error('Invalid response');
     }
 
-    public calculatePhysicalPoint(screenInfo: ScreenInfo, wdaScreen: WdaScreen, position: Position): Point | undefined {
+    public static calculatePhysicalPoint(
+        screenInfo: ScreenInfo,
+        wdaScreen: WdaScreen,
+        position: Position,
+    ): Point | undefined {
         const { statusBarSize } = wdaScreen;
         // ignore the locked video orientation, the events will apply in coordinates considered in the physical device orientation
         const { videoSize, deviceRotation, contentRect } = screenInfo;
-        const { right, left } = contentRect;
-        const scale = (right - left) / statusBarSize.width;
+        const { right, left, bottom, top } = contentRect;
+        let shortSide: number;
+        if (videoSize.width >= videoSize.height) {
+            shortSide = bottom - top;
+        } else {
+            shortSide = right - left;
+        }
+        const scale = shortSide / statusBarSize.width;
 
         // reverse the video rotation to apply the events
         const devicePosition = position.rotate(deviceRotation);

--- a/src/app/applDevice/client/StreamClientQVHack.ts
+++ b/src/app/applDevice/client/StreamClientQVHack.ts
@@ -129,12 +129,12 @@ export class StreamClientQVHack extends BaseClient<ParamsStreamQVHack, never> im
         player.on('video-view-resize', this.onViewVideoResize);
         player.on('input-video-resize', this.onInputVideoResize);
         this.videoWrapper = video;
+
+        document.body.appendChild(deviceView);
         const bounds = StreamClientQVHack.getMaxSize(controlButtons);
         if (bounds) {
             player.setBounds(bounds);
         }
-
-        document.body.appendChild(deviceView);
         this.streamReceiver.on('video', (data) => {
             const STATE = BasePlayer.STATE;
             if (player.getState() === STATE.PAUSED) {

--- a/src/app/player/MsePlayer.ts
+++ b/src/app/player/MsePlayer.ts
@@ -10,9 +10,9 @@ interface QualityStats {
     droppedFrames: number;
 }
 
-// sourceBuffer is private in h264-converter
-type ConverterFake = {
-    sourceBuffer: SourceBuffer;
+type Block = {
+    start: number;
+    end: number;
 };
 
 export class MsePlayer extends BasePlayer {
@@ -52,8 +52,9 @@ export class MsePlayer extends BasePlayer {
     public fpf: number = MsePlayer.DEFAULT_FRAMES_PER_FRAGMENT;
     public readonly supportsScreenshot: boolean = true;
     private sourceBuffer?: SourceBuffer;
-    private removeStart = -1;
-    private removeEnd = -1;
+    private waitUntilSegmentRemoved = false;
+    private blocks: Block[] = [];
+    private frames: Uint8Array[] = [];
     private jumpEnd = -1;
     private lastTime = -1;
     protected canPlay = false;
@@ -65,6 +66,8 @@ export class MsePlayer extends BasePlayer {
     private MAX_TIME_TO_RECOVER = 200; // ms
     private MAX_BUFFER = this.isSafari ? 2 : this.isChrome && this.isMac ? 0.9 : 0.2;
     private MAX_AHEAD = -0.2;
+    protected videoHeight = -1;
+    protected videoWidth = -1;
 
     public static isSupported(): boolean {
         return typeof MediaSource !== 'undefined' && MediaSource.isTypeSupported(mimeType);
@@ -134,6 +137,12 @@ export class MsePlayer extends BasePlayer {
         this.canPlay = true;
         this.tag.play();
         this.tag.removeEventListener('canplay', this.onVideoCanPlay);
+        this.checkVideoResize();
+    }
+
+    protected handleVideoResize(videoWidth: number, videoHeight: number): void {
+        this.videoWidth = videoWidth;
+        this.videoHeight = videoHeight;
     }
 
     protected calculateMomentumStats(): void {
@@ -238,7 +247,15 @@ export class MsePlayer extends BasePlayer {
     public static getPreferredVideoSetting(): VideoSettings {
         return this.preferredVideoSettings;
     }
-
+    checkVideoResize = (): void => {
+        if (!this.tag) {
+            return;
+        }
+        const { videoHeight, videoWidth } = this.tag;
+        if (this.videoHeight !== videoHeight || this.videoWidth !== videoWidth) {
+            this.handleVideoResize(videoWidth, videoHeight);
+        }
+    };
     cleanSourceBuffer = (): void => {
         if (!this.sourceBuffer) {
             return;
@@ -246,12 +263,24 @@ export class MsePlayer extends BasePlayer {
         if (this.sourceBuffer.updating) {
             return;
         }
+        if (this.blocks.length < 10) {
+            return;
+        }
         try {
-            // console.log(this.name, `sourceBuffer.remove(${this.removeStart}, ${this.removeEnd})`);
-            // FIXME: will kill playback in Safari
-            this.sourceBuffer.remove(this.removeStart, this.removeEnd);
             this.sourceBuffer.removeEventListener('updateend', this.cleanSourceBuffer);
-            this.removeStart = this.removeEnd = -1;
+            this.waitUntilSegmentRemoved = false;
+            const removeStart = this.blocks[0].start;
+            const removeEnd = this.blocks[4].end;
+            this.blocks = this.blocks.slice(5);
+            this.sourceBuffer.remove(removeStart, removeEnd);
+            let frame = this.frames.shift();
+            while (frame) {
+                if (!this.checkForIFrame(frame)) {
+                    this.frames.unshift(frame);
+                    break;
+                }
+                frame = this.frames.shift();
+            }
         } catch (e) {
             console.error(`[${this.name}]`, 'Failed to clean source buffer');
         }
@@ -276,11 +305,11 @@ export class MsePlayer extends BasePlayer {
 
     public pushFrame(frame: Uint8Array): void {
         super.pushFrame(frame);
-        if (this.converter) {
-            this.converter.appendRawData(frame);
-            this.checkForIFrame(frame);
+        if (!this.checkForIFrame(frame)) {
+            this.frames.push(frame);
+        } else {
+            this.checkForBadState();
         }
-        this.checkForBadState();
     }
 
     protected checkForBadState(): void {
@@ -375,29 +404,42 @@ export class MsePlayer extends BasePlayer {
         }
     }
 
-    protected checkForIFrame(frame: Uint8Array): void {
-        if (this.isSafari) {
-            return;
+    protected checkForIFrame(frame: Uint8Array): boolean {
+        if (!this.converter) {
+            return false;
         }
+        this.sourceBuffer = this.converter.sourceBuffer;
         if (BasePlayer.isIFrame(frame)) {
             let start = 0;
             let end = 0;
             if (this.tag.buffered && this.tag.buffered.length) {
                 start = this.tag.buffered.start(0);
-                end = this.tag.buffered.end(0) | 0;
+                end = this.tag.buffered.end(0);
             }
             if (end !== 0 && start < end) {
-                const sourceBuffer: SourceBuffer = ((this.converter as unknown) as ConverterFake).sourceBuffer;
-                this.sourceBuffer = sourceBuffer;
-                if (this.removeEnd !== -1) {
-                    this.removeEnd = end;
-                } else {
-                    this.removeStart = start;
-                    this.removeEnd = end;
+                const block: Block = {
+                    start,
+                    end,
+                };
+                this.blocks.push(block);
+                if (this.blocks.length > 10) {
+                    this.waitUntilSegmentRemoved = true;
+
+                    this.sourceBuffer.addEventListener('updateend', this.cleanSourceBuffer);
+                    this.converter.appendRawData(frame);
+                    return true;
                 }
-                sourceBuffer.addEventListener('updateend', this.cleanSourceBuffer);
+            }
+            if (this.sourceBuffer) {
+                this.sourceBuffer.onupdateend = this.checkVideoResize;
             }
         }
+        if (this.waitUntilSegmentRemoved) {
+            return false;
+        }
+
+        this.converter.appendRawData(frame);
+        return true;
     }
 
     private stopConverter(): void {

--- a/src/app/player/MsePlayerForQVHack.ts
+++ b/src/app/player/MsePlayerForQVHack.ts
@@ -18,13 +18,8 @@ export class MsePlayerForQVHack extends MsePlayer {
         super(udid, undefined, 'MSE_Player_For_QVHack', tag);
     }
 
-    protected onCanPlayHandler(): void {
-        super.onCanPlayHandler();
-        const tag = this.tag;
-        const { videoWidth, videoHeight } = tag;
-        if (!videoWidth && !videoHeight) {
-            return;
-        }
+    protected handleVideoResize(videoWidth: number, videoHeight: number): void {
+        super.handleVideoResize(videoWidth, videoHeight);
         let w = videoWidth;
         let h = videoHeight;
         if (this.bounds) {
@@ -50,8 +45,8 @@ export class MsePlayerForQVHack extends MsePlayer {
                 }
                 w = boundsWidth | 0;
                 h = boundsHeight | 0;
-                tag.style.maxWidth = `${w}px`;
-                tag.style.maxHeight = `${h}px`;
+                this.tag.style.maxWidth = `${w}px`;
+                this.tag.style.maxHeight = `${h}px`;
             }
         }
         const realScreen = new ScreenInfo(new Rect(0, 0, videoWidth, videoHeight), new Size(w, h), 0);
@@ -69,10 +64,5 @@ export class MsePlayerForQVHack extends MsePlayer {
 
     public setVideoSettings(): void {
         return;
-    }
-
-    public play(): void {
-        super.play();
-        this.tag.oncanplay = this.onVideoCanPlay;
     }
 }


### PR DESCRIPTION
1. Handle screen rotation (#111)
2. Fix touch coordinates in landscape mode (#112)
3. Fix memory leak in Safari for h264-converter: before, it was impossible to remove old segments from `sourceBuffer`.