### PR TITLE
fix: enable trackers by default

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,7 +1,9 @@
 # Run configuration example. See full config file spec in src/types/Configuration.d.ts
 
-# Device trackers (default: true)
+# Device trackers
+## track android devices (default: true, if was INCLUDE_GOOG enabled in build config)
 runGoogTracker: false
+## track iOS devices (default: true, if was INCLUDE_APPL enabled in build config)
 runApplTracker: false;
 
 # HTTP[s] servers configuration

--- a/src/server/Config.ts
+++ b/src/server/Config.ts
@@ -12,45 +12,81 @@ const JSON_RE = /^.+\.(json|js)$/i;
 
 export class Config {
     private static instance?: Config;
-    public static getInstance(defaultConfig?: Configuration): Config {
-        if (!defaultConfig) {
-            defaultConfig = {
-                runGoogTracker: false,
-                runApplTracker: false,
-                announceGoogTracker: false,
-                announceApplTracker: false,
-            };
-            /// #if INCLUDE_GOOG
-            defaultConfig.runGoogTracker = true;
-            defaultConfig.announceGoogTracker = true;
-            /// #endif
+    private static initConfig(userConfig: Configuration = {}): Configuration {
+        let runGoogTracker = false;
+        let announceGoogTracker = false;
+        /// #if INCLUDE_GOOG
+        runGoogTracker = true;
+        announceGoogTracker = true;
+        /// #endif
 
-            /// #if INCLUDE_APPL
-            defaultConfig.runApplTracker = true;
-            defaultConfig.announceApplTracker = true;
-            /// #endif
+        let runApplTracker = false;
+        let announceApplTracker = false;
+        /// #if INCLUDE_APPL
+        runApplTracker = true;
+        announceApplTracker = true;
+        /// #endif
+        const server: ServerItem[] = [];
+        const defaultConfig = {
+            runGoogTracker,
+            runApplTracker,
+            announceGoogTracker,
+            announceApplTracker,
+            server,
+        };
+        const merged = Object.assign({}, defaultConfig, userConfig);
+        merged.server = merged.server.map((item) => this.parseServerItem(item));
+        return merged;
+    }
+    private static parseServerItem(config: Partial<ServerItem> = {}): ServerItem {
+        const secure = config.secure || false;
+        const port = config.port || (secure ? 443 : 80);
+        const options = config.options;
+        const redirectToSecure = config.redirectToSecure || false;
+        if (secure && !options) {
+            throw Error('Must provide "options" for secure server configuration');
         }
+        if (options?.certPath) {
+            if (options.cert) {
+                throw Error(`Can't use "cert" and "certPath" together`);
+            }
+            options.cert = this.readFile(options.certPath);
+        }
+        if (options?.keyPath) {
+            if (options.key) {
+                throw Error(`Can't use "key" and "keyPath" together`);
+            }
+            options.key = this.readFile(options.keyPath);
+        }
+        return {
+            secure,
+            port,
+            options,
+            redirectToSecure,
+        };
+    }
+    public static getInstance(): Config {
         if (!this.instance) {
-            this.instance = new Config(defaultConfig);
+            const configPath = process.env[EnvName.CONFIG_PATH];
+            let userConfig: Configuration;
+            if (!configPath) {
+                userConfig = {};
+            } else {
+                if (configPath.match(YAML_RE)) {
+                    userConfig = YAML.parse(this.readFile(configPath));
+                } else if (configPath.match(JSON_RE)) {
+                    userConfig = JSON.parse(this.readFile(configPath));
+                } else {
+                    throw Error(`Unknown file type: ${configPath}`);
+                }
+            }
+            const fullConfig = this.initConfig(userConfig);
+            this.instance = new Config(fullConfig);
         }
         return this.instance;
     }
 
-    constructor(private fullConfig: Configuration) {
-        const configPath = process.env[EnvName.CONFIG_PATH];
-        if (!configPath) {
-            return;
-        }
-        if (configPath.match(YAML_RE)) {
-            this.fullConfig = YAML.parse(this.readFile(configPath));
-        } else if (configPath.match(JSON_RE)) {
-            this.fullConfig = JSON.parse(this.readFile(configPath));
-        } else {
-            throw Error(`Unknown file type: ${configPath}`);
-        }
-    }
-
-    public readFile(pathString: string): string {
+    public static readFile(pathString: string): string {
         const isAbsolute = pathString.startsWith('/');
         const absolutePath = isAbsolute ? pathString : path.resolve(process.cwd(), pathString);
         if (!fs.existsSync(absolutePath)) {
@@ -58,6 +94,8 @@ export class Config {
         }
         return fs.readFileSync(absolutePath).toString();
     }
+
+    constructor(private fullConfig: Configuration) {}
 
     public getHostList(): HostItem[] {
         if (!this.fullConfig.remoteHostList || !this.fullConfig.remoteHostList.length) {
@@ -83,29 +121,29 @@ export class Config {
         return hostList;
     }
 
-    public getRunLocalGoogTracker(): boolean {
+    public get runLocalGoogTracker(): boolean {
         return !!this.fullConfig.runGoogTracker;
     }
 
-    public getAnnounceLocalGoogTracker(): boolean {
+    public get announceLocalGoogTracker(): boolean {
         if (typeof this.fullConfig.announceGoogTracker === 'boolean') {
             return this.fullConfig.announceGoogTracker;
         }
         return this.fullConfig.runGoogTracker === true;
     }
 
-    public getRunLocalApplTracker(): boolean {
+    public get runLocalApplTracker(): boolean {
         return !!this.fullConfig.runApplTracker;
     }
 
-    public getAnnounceLocalApplTracker(): boolean {
+    public get announceLocalApplTracker(): boolean {
         if (typeof this.fullConfig.announceApplTracker === 'boolean') {
             return this.fullConfig.announceApplTracker;
         }
         return this.fullConfig.runApplTracker === true;
     }
 
-    public getServers(): ServerItem[] {
+    public get servers(): ServerItem[] {
         if (!Array.isArray(this.fullConfig.server)) {
             return [
                 {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -28,11 +28,11 @@ async function loadGoogModules() {
     const { DeviceTracker } = await import('./goog-device/mw/DeviceTracker');
     const { WebsocketProxyOverAdb } = await import('./goog-device/mw/WebsocketProxyOverAdb');
 
-    if (config.getRunLocalGoogTracker()) {
+    if (config.runLocalGoogTracker) {
         mw2List.push(DeviceTracker);
     }
 
-    if (config.getAnnounceLocalGoogTracker()) {
+    if (config.announceLocalGoogTracker) {
         HostTracker.registerLocalTracker(DeviceTracker);
     }
 
@@ -70,11 +70,11 @@ async function loadApplModules() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (global as any)._global_npmlog = npmlog;
 
-    if (config.getRunLocalApplTracker()) {
+    if (config.runLocalApplTracker) {
         mw2List.push(DeviceTracker);
     }
 
-    if (config.getAnnounceLocalApplTracker()) {
+    if (config.announceLocalApplTracker) {
         HostTracker.registerLocalTracker(DeviceTracker);
     }
 

--- a/src/server/services/HttpServer.ts
+++ b/src/server/services/HttpServer.ts
@@ -82,7 +82,7 @@ export class HttpServer extends TypedEmitter<HttpServerEvents> implements Servic
             /// #endif
         }
         const config = Config.getInstance();
-        config.getServers().forEach((serverItem) => {
+        config.servers.forEach((serverItem) => {
             const { secure, port, redirectToSecure } = serverItem;
             let proto: string;
             let server: http.Server | https.Server;
@@ -90,22 +90,7 @@ export class HttpServer extends TypedEmitter<HttpServerEvents> implements Servic
                 if (!serverItem.options) {
                     throw Error('Must provide option for secure server configuration');
                 }
-                let { key, cert } = serverItem.options;
-                const { keyPath, certPath } = serverItem.options;
-                if (!key) {
-                    if (typeof keyPath !== 'string') {
-                        throw Error('Must provide parameter "key" or "keyPath"');
-                    }
-                    key = config.readFile(keyPath);
-                }
-                if (!cert) {
-                    if (typeof certPath !== 'string') {
-                        throw Error('Must provide parameter "cert" or "certPath"');
-                    }
-                    cert = config.readFile(certPath);
-                }
-                const options = { ...serverItem.options, cert, key };
-                server = https.createServer(options, this.mainApp);
+                server = https.createServer(serverItem.options, this.mainApp);
                 proto = 'https';
             } else {
                 const options = serverItem.options ? { ...serverItem.options } : {};


### PR DESCRIPTION
Before this `runGoogTracker` and `runApplTracker` were enabled only when no configuration file was provided.
Now it will also fallback to default values when provided configuration does not have these fields.

fix #164