### PR TITLE
Feat: pathname

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ established over adb.
 You can specify a path to a configuration file in `WS_SCRCPY_CONFIG`
 environment variable.
 
+If you want to have another pathname than "/" you can specify it in the
+`WS_SCRCPY_PATHNAME` environment variable.
+
 Configuration file format: [Configuration.d.ts](/src/types/Configuration.d.ts).
 
 Configuration file example: [config.example.yaml](/config.example.yaml).

--- a/src/app/Attribute.ts
+++ b/src/app/Attribute.ts
@@ -9,5 +9,6 @@ export const Attribute = {
     SECURE: 'data-secure',
     HOSTNAME: 'data-hostname',
     PORT: 'data-port',
+    PATHNAME: 'data-pathname',
     VALUE: 'data-value',
 };

--- a/src/app/client/BaseClient.ts
+++ b/src/app/client/BaseClient.ts
@@ -22,6 +22,7 @@ export class BaseClient<P extends ParamsBase, TE extends EventMap> extends Typed
             secure: Util.parseBooleanEnv(query.get('secure')),
             hostname: Util.parseStringEnv(query.get('hostname')),
             port: Util.parseIntEnv(query.get('port')),
+            pathname: Util.parseStringEnv(query.get('pathname')),
         };
     }
 

--- a/src/app/client/BaseDeviceTracker.ts
+++ b/src/app/client/BaseDeviceTracker.ts
@@ -32,8 +32,9 @@ export abstract class BaseDeviceTracker<DD extends BaseDeviceDescriptor, TE exte
 
     public static buildUrl(item: HostItem): URL {
         const { secure, port, hostname } = item;
+        const pathname = item.pathname ?? '/';
         const protocol = secure ? 'wss:' : 'ws:';
-        const url = new URL(`${protocol}//${hostname}`);
+        const url = new URL(`${protocol}//${hostname}${pathname}`);
         if (port) {
             url.port = port.toString();
         }
@@ -49,19 +50,22 @@ export abstract class BaseDeviceTracker<DD extends BaseDeviceDescriptor, TE exte
     public static buildLink(q: any, text: string, params: ParamsDeviceTracker): HTMLAnchorElement {
         let { hostname } = params;
         let port: string | number | undefined = params.port;
+        let pathname = params.pathname ?? location.pathname;
         let protocol = params.secure ? 'https:' : 'http:';
         if (params.useProxy) {
             q.hostname = hostname;
             q.port = port;
+            q.pathname = pathname;
             q.secure = params.secure;
             q.useProxy = true;
             protocol = location.protocol;
             hostname = location.hostname;
             port = location.port;
+            pathname = location.pathname;
         }
         const hash = `#!${new URLSearchParams(q).toString()}`;
         const a = document.createElement('a');
-        a.setAttribute('href', `${protocol}//${hostname}:${port}/${hash}`);
+        a.setAttribute('href', `${protocol}//${hostname}:${port}${pathname}${hash}`);
         a.setAttribute('rel', 'noopener noreferrer');
         a.setAttribute('target', '_blank');
         a.classList.add(`link-${q.action}`);

--- a/src/app/client/HostTracker.ts
+++ b/src/app/client/HostTracker.ts
@@ -69,12 +69,12 @@ export class HostTracker extends ManagerClient<ParamsBase, HostTrackerEvents> {
                     msg.data.local.forEach(({ type }) => {
                         const secure = location.protocol === 'https:';
                         const port = location.port ? parseInt(location.port, 10) : secure ? 443 : 80;
-                        const { hostname } = location;
+                        const { hostname, pathname } = location;
                         if (type !== 'android' && type !== 'ios') {
                             console.warn(TAG, `Unsupported host type: "${type}"`);
                             return;
                         }
-                        const hostItem: HostItem = { useProxy: false, secure, port, hostname, type };
+                        const hostItem: HostItem = { useProxy: false, secure, port, hostname, pathname, type };
                         this.startTracker(hostItem);
                     });
                 }

--- a/src/app/client/ManagerClient.ts
+++ b/src/app/client/ManagerClient.ts
@@ -88,15 +88,16 @@ export abstract class ManagerClient<P extends ParamsBase, TE extends EventMap> e
 
     protected buildDirectWebSocketUrl(): URL {
         const { hostname, port, secure, action } = this.params;
+        const pathname = this.params.pathname ?? location.pathname;
         let urlString: string;
         if (typeof hostname === 'string' && typeof port === 'number') {
             const protocol = secure ? 'wss:' : 'ws:';
-            urlString = `${protocol}//${hostname}:${port}`;
+            urlString = `${protocol}//${hostname}:${port}${pathname}`;
         } else {
             const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
 
             // location.host includes hostname and port
-            urlString = `${protocol}${location.host}`;
+            urlString = `${protocol}${location.host}${pathname}`;
         }
         const directUrl = new URL(urlString);
         if (this.supportMultiplexing()) {

--- a/src/app/googDevice/client/DeviceTracker.ts
+++ b/src/app/googDevice/client/DeviceTracker.ts
@@ -148,7 +148,8 @@ export class DeviceTracker extends BaseDeviceTracker<GoogDeviceDescriptor, never
         const secure = !!params.secure;
         const hostname = params.hostname || location.hostname;
         const port = typeof params.port === 'number' ? params.port : secure ? 443 : 80;
-        const urlObject = this.buildUrl({ ...params, secure, hostname, port });
+        const pathname = params.pathname || location.pathname;
+        const urlObject = this.buildUrl({ ...params, secure, hostname, port, pathname });
         if (udid) {
             urlObject.searchParams.set('action', ACTION.PROXY_ADB);
             urlObject.searchParams.set('remote', `tcp:${SERVER_PORT.toString(10)}`);

--- a/src/app/googDevice/client/StreamClientScrcpy.ts
+++ b/src/app/googDevice/client/StreamClientScrcpy.ts
@@ -426,6 +426,7 @@ export class StreamClientScrcpy
                     ${Attribute.SECURE}="${params.secure}"
                     ${Attribute.HOSTNAME}="${params.hostname}"
                     ${Attribute.PORT}="${params.port}"
+                    ${Attribute.PATHNAME}="${params.pathname}"
                     ${Attribute.USE_PROXY}="${params.useProxy}"
                     id="${configureButtonId}"
                     class="active action-button"
@@ -447,6 +448,7 @@ export class StreamClientScrcpy
         const secure = Util.parseBooleanEnv(button.getAttribute(Attribute.SECURE) || undefined) || false;
         const hostname = Util.parseStringEnv(button.getAttribute(Attribute.HOSTNAME) || undefined) || '';
         const port = Util.parseIntEnv(button.getAttribute(Attribute.PORT) || undefined);
+        const pathname = Util.parseStringEnv(button.getAttribute(Attribute.PATHNAME) || undefined) || '';
         const useProxy = Util.parseBooleanEnv(button.getAttribute(Attribute.USE_PROXY) || undefined);
         if (!udid) {
             throw Error(`Invalid udid value: "${udid}"`);
@@ -459,6 +461,7 @@ export class StreamClientScrcpy
             secure,
             hostname,
             port,
+            pathname,
             useProxy,
         });
         const descriptor = tracker.getDescriptorByUdid(udid);
@@ -485,6 +488,7 @@ export class StreamClientScrcpy
             secure,
             hostname,
             port,
+            pathname,
             useProxy,
         };
         const dialog = new ConfigureScrcpy(tracker, descriptor, options);

--- a/src/server/Config.ts
+++ b/src/server/Config.ts
@@ -115,19 +115,20 @@ export class Config {
         }
         const hostList: HostItem[] = [];
         this.fullConfig.remoteHostList.forEach((item) => {
-            const { hostname, port, secure, useProxy } = item;
+            const { hostname, port, pathname, secure, useProxy } = item;
             if (Array.isArray(item.type)) {
                 item.type.forEach((type) => {
                     hostList.push({
                         hostname,
                         port,
+                        pathname,
                         secure,
                         useProxy,
                         type,
                     });
                 });
             } else {
-                hostList.push({ hostname, port, secure, useProxy, type: item.type });
+                hostList.push({ hostname, port, pathname, secure, useProxy, type: item.type });
             }
         });
         return hostList;

--- a/src/server/EnvName.ts
+++ b/src/server/EnvName.ts
@@ -1,3 +1,4 @@
 export enum EnvName {
     CONFIG_PATH = 'WS_SCRCPY_CONFIG',
+    WS_SCRCPY_PATHNAME = 'WS_SCRCPY_PATHNAME',
 }

--- a/src/server/Utils.ts
+++ b/src/server/Utils.ts
@@ -1,16 +1,16 @@
 import * as os from 'os';
 
 export class Utils {
-    public static printListeningMsg(proto: string, port: number): void {
+    public static printListeningMsg(proto: string, port: number, pathname: string): void {
         const ipv4List: string[] = [];
         const ipv6List: string[] = [];
         const formatAddress = (ip: string, scopeid: number | undefined): void => {
             if (typeof scopeid === 'undefined') {
-                ipv4List.push(`${proto}://${ip}:${port}`);
+                ipv4List.push(`${proto}://${ip}:${port}${pathname}`);
                 return;
             }
             if (scopeid === 0) {
-                ipv6List.push(`${proto}://[${ip}]:${port}`);
+                ipv6List.push(`${proto}://[${ip}]:${port}${pathname}`);
             } else {
                 return;
                 // skip
@@ -32,7 +32,7 @@ export class Utils {
                     formatAddress(iface.address, scopeid);
                 });
             });
-        const nameList = [encodeURI(`${proto}://${os.hostname()}:${port}`), encodeURI(`${proto}://localhost:${port}`)];
+        const nameList = [encodeURI(`${proto}://${os.hostname()}:${port}${pathname}`), encodeURI(`${proto}://localhost:${port}${pathname}`)];
         console.log('Listening on:\n\t' + nameList.join(' '));
         if (ipv4List.length) {
             console.log('\t' + ipv4List.join(' '));

--- a/src/server/services/HttpServer.ts
+++ b/src/server/services/HttpServer.ts
@@ -128,7 +128,7 @@ export class HttpServer extends TypedEmitter<HttpServerEvents> implements Servic
             }
             this.servers.push({ server, port });
             server.listen(port, () => {
-                Utils.printListeningMsg(proto, port);
+                Utils.printListeningMsg(proto, port, PATHNAME);
             });
         });
         this.started = true;

--- a/src/server/services/HttpServer.ts
+++ b/src/server/services/HttpServer.ts
@@ -11,7 +11,7 @@ import { EnvName } from '../EnvName';
 
 const DEFAULT_STATIC_DIR = path.join(__dirname, './public');
 
-const PATHNAME = process.env[EnvName.WS_SCRCPY_PATHNAME] || '/';
+const PATHNAME = process.env[EnvName.WS_SCRCPY_PATHNAME] || __PATHNAME__;
 
 export type ServerAndPort = {
     server: https.Server | http.Server;

--- a/src/server/services/HttpServer.ts
+++ b/src/server/services/HttpServer.ts
@@ -6,8 +6,12 @@ import { Utils } from '../Utils';
 import express, { Express } from 'express';
 import { Config } from '../Config';
 import { TypedEmitter } from '../../common/TypedEmitter';
+import * as process from 'process';
+import { EnvName } from '../EnvName';
 
 const DEFAULT_STATIC_DIR = path.join(__dirname, './public');
+
+const PATHNAME = process.env[EnvName.WS_SCRCPY_PATHNAME] || '/';
 
 export type ServerAndPort = {
     server: https.Server | http.Server;
@@ -73,7 +77,7 @@ export class HttpServer extends TypedEmitter<HttpServerEvents> implements Servic
     public async start(): Promise<void> {
         this.mainApp = express();
         if (HttpServer.SERVE_STATIC && HttpServer.PUBLIC_DIR) {
-            this.mainApp.use(express.static(HttpServer.PUBLIC_DIR));
+            this.mainApp.use(PATHNAME, express.static(HttpServer.PUBLIC_DIR));
 
             /// #if USE_WDA_MJPEG_SERVER
 

--- a/src/types/Configuration.d.ts
+++ b/src/types/Configuration.d.ts
@@ -7,6 +7,7 @@ export interface HostItem {
     secure: boolean;
     hostname: string;
     port: number;
+    pathname?: string;
     useProxy?: boolean;
 }
 
@@ -15,6 +16,7 @@ export interface HostsItem {
     secure: boolean;
     hostname: string;
     port: number;
+    pathname?: string;
     useProxy?: boolean;
 }
 

--- a/src/types/ParamsBase.ts
+++ b/src/types/ParamsBase.ts
@@ -4,4 +4,5 @@ export interface ParamsBase {
     secure?: boolean;
     hostname?: string;
     port?: number;
+    pathname?: string;
 }

--- a/typings/build-config.d.ts
+++ b/typings/build-config.d.ts
@@ -1,0 +1,1 @@
+declare var __PATHNAME__: string;

--- a/webpack/build.config.utils.ts
+++ b/webpack/build.config.utils.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-type BuildConfig = Record<string, boolean>;
+type BuildConfig = Record<string, boolean | string>;
 
 const DEFAULT_CONFIG_PATH = path.resolve(path.dirname(__filename), 'default.build.config.json');
 const configCache: Map<string, BuildConfig> = new Map();
@@ -15,7 +15,7 @@ export function getConfig(filename: string): BuildConfig {
         const rawConfig = JSON.parse(fs.readFileSync(absolutePath).toString());
         Object.keys(rawConfig).forEach((key) => {
             const value = rawConfig[key];
-            if (typeof value === 'boolean') {
+            if (typeof value === 'boolean' || typeof value === 'string') {
                 filtered[key] = value;
             }
         });

--- a/webpack/default.build.config.json
+++ b/webpack/default.build.config.json
@@ -10,5 +10,6 @@
   "INCLUDE_ADB_SHELL": true,
   "INCLUDE_FILE_LISTING": true,
   "INCLUDE_APPL": false,
-  "INCLUDE_GOOG": true
+  "INCLUDE_GOOG": true,
+  "PATHNAME": "/"
 }

--- a/webpack/ws-scrcpy.common.ts
+++ b/webpack/ws-scrcpy.common.ts
@@ -12,8 +12,13 @@ export const SERVER_DIST_PATH = path.join(PROJECT_ROOT, 'dist');
 export const CLIENT_DIST_PATH = path.join(PROJECT_ROOT, 'dist/public');
 const PACKAGE_JSON = path.join(PROJECT_ROOT, 'package.json');
 
+const override = path.join(PROJECT_ROOT, '/build.config.override.json');
+const buildConfigOptions = mergeWithDefaultConfig(override);
+const buildConfigDefinePlugin = new webpack.DefinePlugin({
+    '__PATHNAME__': JSON.stringify(buildConfigOptions.PATHNAME),
+});
+
 export const common = () => {
-    const override = path.join(PROJECT_ROOT, '/build.config.override.json');
     return {
         module: {
             rules: [
@@ -27,7 +32,7 @@ export const common = () => {
                         { loader: 'ts-loader' },
                         {
                             loader: 'ifdef-loader',
-                            options: mergeWithDefaultConfig(override),
+                            options: buildConfigOptions,
                         },
                     ],
                     exclude: /node_modules/,
@@ -134,7 +139,10 @@ delete packageJson.devDependencies;
 const back: webpack.Configuration = {
     entry: path.join(PROJECT_ROOT, './src/server/index.ts'),
     externals: [nodeExternals()],
-    plugins: [new GeneratePackageJsonPlugin(basePackage)],
+    plugins: [
+        new GeneratePackageJsonPlugin(basePackage),
+        buildConfigDefinePlugin,
+    ],
     node: {
         global: false,
         __filename: false,


### PR DESCRIPTION
In our setup we have ws-scrcpy behind an nginx protected with http auth. We wanted to have it on a separate pathname ( /ws-scrcpy ) and added the possibility to define a env variable WS_SCRCPY_PATHNAME which configures ws-scrcpy work like that.