### PR TITLE
Defekkt docker support via USB - network separation

### DIFF
--- a/docs/docker-nativeadb.md
+++ b/docs/docker-nativeadb.md
@@ -1,0 +1,85 @@
+# Using Docker without ADB over IP
+Some Scenarios prefer or require not having the phone we want to control on the same network as the ws-scrcpy server.
+## Requirements:
+- ADB-Server running on a system with usb connection to the target android device(s) - IP: ANDROID_ADB_SERVER_ADDRESS
+- Docker image running ws-scrpcy must have tcp connection to the ADB-Server
+- Client using Web-Browser to control the phones must be able to connect to the ADB-Server via websocket, ip "exposed" to the client: - IP: HOST_IP_ADDRESS
+    - the ADB-Server will forward the websocket directly to the phone, but not via tcp as per the usual ws-scrpy setup, but via USB.
+
+## scheme overview
+
+The diagram below shows the documented setup: the ADB server runs on the host (has the USB-connected Android device), the ws-scrcpy server runs inside a Docker container and connects to the host ADB server using `host.docker.internal` (configured via `ANDROID_ADB_SERVER_ADDRESS`). The browser client connects to the ws-scrcpy HTTP/WS endpoint exposed by Docker (host port mapped to container port).
+
+```
+                                         +---------------------------------------+
+                                         |  Browser (Client)                     |
+                                         |  - connects to webif                  |
+                                         |  - opens WS to android via adb-server |
+                                         +-----------+---------------------------+
+                                                     |
+                                                     | HTTP / WS
+                                                     |
+    Host machine (runs ADB server)         <-------- + --------> Docker container (ws-scrcpy)
+  +-----------------------------------+              |    +------------------------------------+
+  | Android device (USB)              |              |    | ws-scrcpy webapp (Node.js)         |
+  |  - ws-scrcpy server/listener      |              |    |  - HTTP server (8000)              |
+  +----------------+------------------+              |    |  - uses ANDROID_ADB_SERVER_ADDRESS |
+                  USB                                |    |    (host.docker.internal)          |
+                                                     |    |  - configures adb-server to        |
+  (adb daemon, listens on 127.0.0.1:5037)            |    |    forward ws to android device    |
+                                                     |    +------------+-----------------------+
+                                                     |                 |
+                                                     |                 | TCP websocket
+                                                     |                 | (to forwarded port)
+                                                     |                 v
+  (adb forward) host tcp:7001  <--------->  android-device: running ws-scrcpy server/listener
+
+Notes:
+- Set ANDROID_ADB_SERVER_ADDRESS=host.docker.internal in the container so the app connects to the host ADB server.
+- The container uses adb-forwarded host ports (ADB_FORWARD_PORT_START) to reach device devtools sockets.
+- Clients connect to the ws-scrcpy HTTP/WS endpoint exposed by Docker (HOST_IP_ADDRESS should be reachable by the client browser).
+```
+
+## systemd adb example
+- add user:
+`sudo useradd --system --home /var/lib/adb --shell /usr/sbin/nologin --groups plugdev adb`
+- systemd service 
+`/etc/systemd/system/adb.service`
+```
+[Unit]
+Description=Android Debug Bridge Server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/adb -a nodaemon server start
+Restart=always
+RestartSec=5
+User=adb
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## docker-compose example
+TODO: update/switch/add Dockerfile
+```
+services:
+  ws-scrcpy:
+    build: .
+    image: local/ws-scrcpy
+    volumes:
+      - ./ws-scrcpy/:/app
+    ports:
+      - 8001:8000
+
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      # ip of host running adb for webclients:
+      HOST_IP_ADDRESS: "host_ip_of_adb-server-reachable-by-user-accessing-ws-scrcpy"
+      # address of adb server from this container:
+      ANDROID_ADB_SERVER_ADDRESS: "host.docker.internal"
+      ADB_FORWARD_PORT_START: "7000"
+      ADB_HOST: "host.docker.internal"
+```

--- a/src/server/goog-device/AdbUtils.ts
+++ b/src/server/goog-device/AdbUtils.ts
@@ -137,22 +137,56 @@ export class AdbUtils {
         });
     }
 
-    public static async forward(serial: string, remote: string): Promise<number> {
-        const client = AdbExtended.createClient();
-        const forwards = await client.listForwards(serial);
-        const forward = forwards.find((item: Forward) => {
-            return item.remote === remote && item.local.startsWith('tcp:') && item.serial === serial;
-        });
-        if (forward) {
-            const { local } = forward;
-            return parseInt(local.split('tcp:')[1], 10);
-        }
+public static async forward(serial: string, remote: string): Promise<number> {
+    const client = AdbExtended.createClient();
+
+    const forwards = await client.listForwards(serial);
+    const forward = forwards.find((f: Forward) =>
+        f.remote === remote && f.local.startsWith("tcp:") && f.serial === serial
+    );
+    if (forward) {
+        const port = parseInt(forward.local.split("tcp:")[1], 10);
+        console.log("[AdbUtils.forward] Using existing forward:", port);
+        return port;
+    }
+
+    // Check if running in Docker by looking at ANDROID_ADB_SERVER_ADDRESS
+    const isDocker = process.env.ANDROID_ADB_SERVER_ADDRESS?.toLowerCase().includes('docker');
+    
+    if (!isDocker) {
+        // running natively, we can use portfinder:
         const port = await portfinder.getPortPromise();
         const local = `tcp:${port}`;
         await client.forward(serial, local, remote);
         return port;
     }
+    // running in Docker, try multiple ports:
+    const maxRetries = 20;
+    let port =1337;
+    port = Number(process.env.ADB_FORWARD_PORT_START ?? 8000);
+    for (let i = 0; i < maxRetries; i++) {
+        try {
+	    port++;
+            const local = `tcp:${port}`;
+            await client.forward(serial, local, remote);
+            console.log("[AdbUtils.forward] Successfully forwarded to port", port);
+            return port;
+        } catch (err: any) {
+            if (err.message?.includes("cannot bind listener")) {
+                console.warn(`[AdbUtils.forward] Port ${port} bind failed, retrying...`);
+                continue;
+            } else {
+                console.error("[AdbUtils.forward] Unexpected error:", err);
+                throw err;
+            }
+        }
+    }
 
+    throw new Error("Failed to bind any available port after multiple attempts");
+}
+
+
+    
     public static async getDevtoolsRemoteList(serial: string): Promise<string[]> {
         const client = AdbExtended.createClient();
         const stream = await client.shell(serial, 'cat /proc/net/unix');

--- a/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
+++ b/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
@@ -50,7 +50,10 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
         const service = new WebsocketProxy(ws);
         AdbUtils.forward(udid, remote)
             .then((port) => {
-                return service.init(`ws://127.0.0.1:${port}${path ? path : ''}`);
+                // host address is where the browser connects to the websocket, so must be accessible from there
+                // browser --websocket--> adb-server forwarding to --> ws-scrcpy on the device
+                const host = process.env.HOST_IP_ADDRESS || '127.0.0.1';
+                return service.init(`ws://${host}:${port}${path || ''}`);
             })
             .catch((e) => {
                 const msg = `[${this.TAG}] Failed to start service: ${e.message}`;


### PR DESCRIPTION
I wanted to separate the network the android device is using, from the network the "controller" is using when accessing the web-interface.

The idea is basically to run ADB on a host which has a USB connection to the android device(s). 
Since I still wanted to use Docker, I made some changes required for this.

Documentation is not 100% there yet, but I figured before I add more, let's see if there is interest in such a (albeit small and niche) feature.

Feedback highly welcome. 🙏 