### PR TITLE
feat(stream): add captureKeyboard URL param to auto-enable keyboard capture

### DIFF
--- a/src/app/googDevice/client/StreamClientScrcpy.ts
+++ b/src/app/googDevice/client/StreamClientScrcpy.ts
@@ -158,6 +158,7 @@ export class StreamClientScrcpy
             player: Util.parseString(params, 'player', true),
             udid: Util.parseString(params, 'udid', true),
             ws: Util.parseString(params, 'ws', true),
+            captureKeyboard: Util.parseBoolean(params, 'captureKeyboard', false),
         };
     }
 
@@ -315,7 +316,9 @@ export class StreamClientScrcpy
         const googMoreBox = (this.moreBox = new GoogMoreBox(udid, player, this));
         const moreBox = googMoreBox.getHolderElement();
         googMoreBox.setOnStop(stop);
-        const googToolBox = GoogToolBox.createToolBox(udid, player, this, moreBox);
+        const googToolBox = GoogToolBox.createToolBox(udid, player, this, moreBox, {
+            captureKeyboard: this.params.captureKeyboard,
+        });
         this.controlButtons = googToolBox.getHolderElement();
         deviceView.appendChild(this.controlButtons);
         const video = document.createElement('div');

--- a/src/app/googDevice/toolbox/GoogToolBox.ts
+++ b/src/app/googDevice/toolbox/GoogToolBox.ts
@@ -41,6 +41,12 @@ const BUTTONS = [
     },
 ];
 
+export interface GoogToolBoxOptions {
+    // Start with keyboard capture enabled instead of requiring the user to tick
+    // the "Capture keyboard" checkbox first.
+    captureKeyboard?: boolean;
+}
+
 export class GoogToolBox extends ToolBox {
     protected constructor(list: ToolBoxElement<any>[]) {
         super(list);
@@ -51,6 +57,7 @@ export class GoogToolBox extends ToolBox {
         player: BasePlayer,
         client: StreamClientScrcpy,
         moreBox?: HTMLElement,
+        options: GoogToolBoxOptions = {},
     ): GoogToolBox {
         const playerName = player.getName();
         const list = BUTTONS.slice();
@@ -91,6 +98,10 @@ export class GoogToolBox extends ToolBox {
             const element = el.getElement();
             client.setHandleKeyboardEvents(element.checked);
         });
+        if (options.captureKeyboard) {
+            keyboard.getElement().checked = true;
+            client.setHandleKeyboardEvents(true);
+        }
         elements.push(keyboard);
 
         if (moreBox) {

--- a/src/types/ParamsStreamScrcpy.d.ts
+++ b/src/types/ParamsStreamScrcpy.d.ts
@@ -7,4 +7,5 @@ export interface ParamsStreamScrcpy extends ParamsStream {
     ws: string;
     fitToScreen?: boolean;
     videoSettings?: VideoSettings;
+    captureKeyboard?: boolean;
 }


### PR DESCRIPTION
Add an optional `captureKeyboard `query parameter to the scrcpy stream action. When set (`captureKeyboard=1` or `captureKeyboard=true`), the capture keyboard toolbar checkbox starts checked and keyboard forwarding is enabled on stream start, so a stream can be deep-linked with keyboard input already active.

Default behavior is unchanged: absent or false leaves capture off.