### PR TITLE
feat(stream): fitToScreen deep link + re-encode on resize

### DIFF
--- a/src/app/googDevice/client/StreamClientScrcpy.ts
+++ b/src/app/googDevice/client/StreamClientScrcpy.ts
@@ -142,6 +142,12 @@ export class StreamClientScrcpy
         }
 
         const { udid, player: playerName } = this.params;
+        // Allow the stream deep link to start already fit to screen
+        // (?fitToScreen=1), so an embedded/auto-started stream can request it
+        // without going through the Configure screen.
+        if (typeof fitToScreen !== 'boolean') {
+            fitToScreen = this.params.fitToScreen;
+        }
         this.startStream({ udid, player, playerName, fitToScreen, videoSettings });
         this.setBodyClass('stream');
     }
@@ -159,6 +165,7 @@ export class StreamClientScrcpy
             udid: Util.parseString(params, 'udid', true),
             ws: Util.parseString(params, 'ws', true),
             captureKeyboard: Util.parseBoolean(params, 'captureKeyboard', false),
+            fitToScreen: params.has('fitToScreen') ? Util.parseBoolean(params, 'fitToScreen') : undefined,
         };
     }
 
@@ -260,6 +267,11 @@ export class StreamClientScrcpy
         this.filePushHandler = undefined;
         this.touchHandler?.release();
         this.touchHandler = undefined;
+        window.removeEventListener('resize', this.onWindowResize);
+        if (this.resizeTimeoutId !== undefined) {
+            clearTimeout(this.resizeTimeoutId);
+            this.resizeTimeoutId = undefined;
+        }
     };
 
     public startStream({ udid, player, playerName, videoSettings, fitToScreen }: StartParams): void {
@@ -348,7 +360,40 @@ export class StreamClientScrcpy
         streamReceiver.on('displayInfo', this.onDisplayInfo);
         streamReceiver.on('disconnected', this.onDisconnected);
         console.log(TAG, player.getName(), udid);
+
+        // When the player is in fit-to-screen mode, re-encode the stream at the
+        // new container size on window resize (debounced) so it stays crisp
+        // instead of being CSS-scaled. Inert when the user picked a fixed
+        // resolution.
+        window.addEventListener('resize', this.onWindowResize);
     }
+
+    private resizeTimeoutId?: ReturnType<typeof setTimeout>;
+
+    private onWindowResize = (): void => {
+        if (this.resizeTimeoutId !== undefined) {
+            clearTimeout(this.resizeTimeoutId);
+        }
+        this.resizeTimeoutId = setTimeout(this.applyFitToScreenBounds, 300);
+    };
+
+    private applyFitToScreenBounds = (): void => {
+        this.resizeTimeoutId = undefined;
+        if (!this.player || !this.player.getFitToScreenStatus()) {
+            return;
+        }
+        const newBounds = this.getMaxSize();
+        if (!newBounds) {
+            return;
+        }
+        const current = this.player.getVideoSettings();
+        if (current.bounds && current.bounds.equals(newBounds)) {
+            return;
+        }
+        const updated = StreamClientScrcpy.createVideoSettingsWithBounds(current, newBounds);
+        this.player.setVideoSettings(updated, true, false);
+        this.sendNewVideoSetting(updated);
+    };
 
     public sendMessage(message: ControlMessage): void {
         this.streamReceiver.sendEvent(message);


### PR DESCRIPTION
Adds a `fitToScreen` stream URL param and re-encodes the stream to the container size on resize.

- **`?fitToScreen=1` deep link**: start a stream already fit to its container without going through the Configure screen. Useful for embedded/auto-started streams.
- **Re-encode on resize**: when the player is in fit-to-screen mode, a debounced (300ms) window-resize handler recomputes the container bounds and resends video settings, so the feed settles at native resolution instead of staying CSS-scaled. Inert for fixed-resolution streams. The resize listener/timer is cleaned up on disconnect.

> [!IMPORTANT]
> Requires #390 to work properly. Without #390 the canvas is still pinned to the raw video resolution and letterboxing/scaling doesn't happen, so the re-encode has nothing to fit into. #390 provides the responsive CSS layout (`object-fit: contain`) and removes the parent-element size pin; this PR builds on that to keep the feed crisp after a resize settles.
