### PR TITLE
feat(client): add title URL param to override document title

### DIFF
--- a/src/app/client/BaseClient.ts
+++ b/src/app/client/BaseClient.ts
@@ -23,15 +23,20 @@ export class BaseClient<P extends ParamsBase, TE extends EventMap> extends Typed
             hostname: Util.parseStringEnv(query.get('hostname')),
             port: Util.parseIntEnv(query.get('port')),
             pathname: Util.parseStringEnv(query.get('pathname')),
+            title: Util.parseStringEnv(query.get('title')),
         };
     }
 
     public setTitle(text = this.title): void {
+        // A `title` URL param overrides the automatic per-client title, so an
+        // embedded or popped-out client can show a meaningful document title
+        // (e.g. in a browser tab or detached window).
         let titleTag: HTMLTitleElement | null = document.querySelector('head > title');
         if (!titleTag) {
             titleTag = document.createElement('title');
+            document.head.appendChild(titleTag);
         }
-        titleTag.innerText = text;
+        titleTag.innerText = this.params?.title || text;
     }
 
     public setBodyClass(text: string): void {

--- a/src/types/ParamsBase.ts
+++ b/src/types/ParamsBase.ts
@@ -5,4 +5,5 @@ export interface ParamsBase {
     hostname?: string;
     port?: number;
     pathname?: string;
+    title?: string;
 }


### PR DESCRIPTION
Adds an optional `title` URL param that overrides the automatic document title.

Client titles are currently hardcoded per type (`Stream <deviceName>`, `Shell <udid>`, `Devtools <udid>`, `Listing <serial>`, `<deviceName>. Configure stream`). When a client is embedded in an iframe or opened in a detached/popup window, there's no way to give it a meaningful tab/window title.

This parses `title` into `ParamsBase` alongside the other shared params (`useProxy`, `secure`, `hostname`, ...), so every client picks it up through the existing `super.parseParameters()` chain. `BaseClient.setTitle` then prefers `params.title` over the automatic title. When the param is absent, behavior is unchanged.

Example:

```
#!action=stream&udid=...&player=webcodecs&title=Pixel%207%20(API%2034)
```

Also appends the `<title>` element to `<head>` in the (previously dead) branch that creates one, so the fallback actually works.
